### PR TITLE
fix: get the most recently created room, if we have multiple rooms with same name

### DIFF
--- a/src/controllers/logbook.controller.ts
+++ b/src/controllers/logbook.controller.ts
@@ -268,7 +268,7 @@ export class LogbookController {
           accessToken,
         );
 
-        const roomId = allRooms.rooms[0].room_id;
+        const roomId = (allRooms.rooms.pop() as ChatRoom).room_id;
 
         const defaultFilter: LogbookFilters = {
           textSearch: "",
@@ -353,7 +353,7 @@ export class LogbookController {
           accessToken,
         );
 
-        const roomId = allRooms.rooms[0].room_id;
+        const roomId = (allRooms.rooms.pop() as ChatRoom).room_id;
 
         const { message } = data;
         return await this.synapseService.sendMessage(


### PR DESCRIPTION
## Description

Every time we use `fetchRoomIdByName` we get all the rooms with same name including old rooms as well as the latest one. And the newly created one is the last index of the array. 
So I changed `allRooms.rooms[0].room_id` to `allRooms.rooms.pop().room_id`, so that we always get the latest one.
This is a temporary solution, we should figure out a better way to address this issue. 

## Motivation

Background on use case, changes needed

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)
- [ ] Docs updated?
- [ ] New packages used/requires npm install?
- [ ] Toggle added for new features?
